### PR TITLE
Unify scheduler interval property naming

### DIFF
--- a/backend/api/admin_routes_v2.py
+++ b/backend/api/admin_routes_v2.py
@@ -4,7 +4,7 @@ Enhanced admin routes with database configuration management
 from fastapi import APIRouter, HTTPException, Depends, Header, BackgroundTasks, Query, Path
 from typing import Optional, Dict, Any, List
 from datetime import datetime
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, AliasChoices
 import logging
 import os
 
@@ -73,7 +73,11 @@ class FieldMappingsConfig(BaseModel):
 
 
 class SyncConfig(BaseModel):
-    interval: int = Field(ge=1, le=1440)
+    interval_minutes: int = Field(
+        ge=1,
+        le=1440,
+        validation_alias=AliasChoices("interval_minutes", "interval"),
+    )
     enabled: bool = True
 
 

--- a/backend/api/scheduler_routes.py
+++ b/backend/api/scheduler_routes.py
@@ -2,7 +2,7 @@
 Scheduler management API routes
 """
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, AliasChoices
 from typing import Optional
 import logging
 
@@ -13,7 +13,12 @@ logger = logging.getLogger(__name__)
 class SchedulerConfig(BaseModel):
     """Scheduler configuration model"""
     enabled: bool
-    interval_minutes: int = Field(ge=2, le=1440, description="Sync interval in minutes (minimum 2)")
+    interval_minutes: int = Field(
+        ge=2,
+        le=1440,
+        description="Sync interval in minutes (minimum 2)",
+        validation_alias=AliasChoices("interval_minutes", "interval"),
+    )
 
 
 class SchedulerStatus(BaseModel):

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -1,7 +1,7 @@
 """
 Pydantic models for API request/response schemas
 """
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, AliasChoices
 from datetime import datetime
 from typing import Optional, List, Dict, Any
 from enum import Enum
@@ -26,7 +26,12 @@ class HealthCheck(BaseModel):
 
 class SyncConfig(BaseModel):
     """Sync configuration"""
-    interval_minutes: int = Field(ge=2, le=1440, description="Sync interval in minutes (minimum 2)")
+    interval_minutes: int = Field(
+        ge=2,
+        le=1440,
+        description="Sync interval in minutes (minimum 2)",
+        validation_alias=AliasChoices("interval_minutes", "interval"),
+    )
     enabled: bool = Field(default=True, description="Whether automatic sync is enabled")
     
     model_config = ConfigDict(from_attributes=True)

--- a/frontend/app/admin/scheduler/page.tsx
+++ b/frontend/app/admin/scheduler/page.tsx
@@ -32,7 +32,7 @@ export default function SchedulerPage() {
       if (!response.ok) throw new Error("Failed to fetch scheduler status")
       const data = await response.json()
       setStatus(data)
-      setIntervalValue([data.interval_minutes])
+      setIntervalValue([data.interval_minutes ?? data.interval])
       setEnabled(data.enabled)
     } catch (error) {
       toast({
@@ -60,6 +60,7 @@ export default function SchedulerPage() {
         body: JSON.stringify({
           enabled: enabled,
           interval_minutes: intervalValue[0],
+          interval: intervalValue[0],
         }),
       })
 


### PR DESCRIPTION
## Summary
- Normalize scheduler config fields to `interval_minutes` across backend and frontend
- Accept legacy `interval` via Pydantic aliases for backward compatibility
- Frontend scheduler page now handles both names when fetching and updating

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897d43876a88329920049a5c6606723