### PR TITLE
chore: remove unused os import

### DIFF
--- a/backend/monitoring.py
+++ b/backend/monitoring.py
@@ -2,7 +2,6 @@
 Monitoring functions for the application
 """
 import psutil
-import os
 from core.db.db_core import get_connection
 
 def monitor_database_size():


### PR DESCRIPTION
## Summary
- remove unused os import in monitoring module

## Testing
- `ruff check backend/monitoring.py`


------
https://chatgpt.com/codex/tasks/task_e_6897e2bcea288329b96cb5284ae75bde