### PR TITLE
refactor: remove unused sync initializer

### DIFF
--- a/backend/core/sync/__init__.py
+++ b/backend/core/sync/__init__.py
@@ -58,18 +58,8 @@ def create_sync_manager(
 def create_status_manager() -> StatusManager:
     """
     Create a configured status manager.
-    
+
     Returns:
         Configured StatusManager instance
     """
     return StatusManager()
-
-def initialize_sync():
-    """
-    Initialize sync system.
-    
-    This function should be called when the application starts
-    to ensure all necessary sync components are initialized.
-    """
-    # Future initialization logic can be added here
-    pass


### PR DESCRIPTION
## Summary
- drop unused `initialize_sync` placeholder from sync package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6897e2b1b5a883298a193af65b1f9972