### PR TITLE
Raise detailed ImportError in sync wrapper

### DIFF
--- a/backend/core/sync_wrapper.py
+++ b/backend/core/sync_wrapper.py
@@ -17,4 +17,4 @@ def get_sync_functions():
         }
     except ImportError as e:
         print(f"Warning: Could not import main_parent module: {e}")
-        raise
+        raise ImportError(f"Could not import main_parent module: {e}") from e


### PR DESCRIPTION
## Summary
- Propagate `ImportError` from `get_sync_functions` so import failures surface properly

## Testing
- `python -m py_compile backend/core/sync_wrapper.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*


------
https://chatgpt.com/codex/tasks/task_e_6897e2b02abc8329b8f3ba67e3cd6ace