### PR TITLE
Add status mapping for issue transition processing

### DIFF
--- a/backend/core/jira/field_processor.py
+++ b/backend/core/jira/field_processor.py
@@ -11,6 +11,71 @@ from dateutil import parser
 # Configure logging
 logger = logging.getLogger(__name__)
 
+# Mapping of transition names to accepted status values
+STATUS_MAPPING = {
+    "scheduled": [
+        "scheduled",
+        "Scheduled",
+    ],
+    "acknowledged": [
+        "acknowledged",
+        "ACKNOWLEDGED",
+        "Acknowledged",
+        "ack",
+        "acknowledged by agent",
+    ],
+    "at_listing": [
+        "at listing",
+        "At Listing",
+        "AT LISTING",
+        "listing",
+        "at_listing",
+    ],
+    "shoot_complete": [
+        "shoot complete",
+        "Shoot Complete",
+        "SHOOT COMPLETE",
+        "shooting complete",
+        "shoot_complete",
+    ],
+    "uploaded": [
+        "uploaded",
+        "Uploaded",
+        "UPLOADED",
+        "upload complete",
+        "upload_complete",
+    ],
+    "edit_start": [
+        "edit start",
+        "Edit Start",
+        "Edit",
+        "EDIT",
+        "editing started",
+        "edit_start",
+    ],
+    "final_review": [
+        "final review",
+        "Final Review",
+        "Managing Partner Ready",
+        "final_review",
+        "pending review",
+    ],
+    "escalated_editing": [
+        "escalated editing",
+        "Escalated Editing",
+    ],
+    "closed": [
+        "closed",
+        "Closed",
+        "CLOSED",
+        "Complete",
+        "Done",
+        "complete",
+        "completed",
+        "done",
+    ],
+}
+
 class FieldProcessingError(Exception):
     """Exception for field processing errors"""
     pass


### PR DESCRIPTION
## Summary
- define `STATUS_MAPPING` constant for issue transition status lookups
- ensure `process_issue_transitions` uses mapping for all transition keys

## Testing
- `python -m flake8 backend/core/jira/field_processor.py` *(fails: No module named flake8)*
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*
- `python - <<'PY'
import sys
sys.path.append('backend')
from core.jira.field_processor import FieldProcessor
fp = FieldProcessor()
print(fp.process_issue_transitions('ISS-1', {}))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6897e2aaf20483298142c78325db572c