### PR TITLE
Surface frontend errors with toasts

### DIFF
--- a/frontend/app/admin/field-mappings/page.tsx
+++ b/frontend/app/admin/field-mappings/page.tsx
@@ -45,9 +45,19 @@ export default function FieldMappingsPage() {
         console.error('Failed to fetch config:', response.status, response.statusText)
         const errorText = await response.text()
         console.error('Error details:', errorText)
+        toast({
+          title: 'Error',
+          description: 'Failed to fetch field mappings',
+          variant: 'destructive'
+        })
       }
     } catch (error) {
       console.error('Failed to fetch config:', error)
+      toast({
+        title: 'Error',
+        description: 'Failed to fetch field mappings',
+        variant: 'destructive'
+      })
     } finally {
       setLoading(false)
     }
@@ -224,6 +234,11 @@ export default function FieldMappingsPage() {
       }
     } catch (error) {
       console.error('Failed to fetch cached fields:', error)
+      toast({
+        title: 'Error',
+        description: 'Failed to fetch cached fields',
+        variant: 'destructive'
+      })
     }
   }
 

--- a/frontend/app/admin/inua-test/page.tsx
+++ b/frontend/app/admin/inua-test/page.tsx
@@ -84,6 +84,11 @@ export default function INUATestPage() {
       setWorkflowInfo(response.data)
     } catch (err) {
       console.error('Failed to fetch workflow info:', err)
+      toast({
+        title: 'Error',
+        description: 'Failed to fetch workflow info',
+        variant: 'destructive',
+      })
     }
   }
 

--- a/frontend/app/admin/performance/page.tsx
+++ b/frontend/app/admin/performance/page.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label'
 import { Slider } from '@/components/ui/slider'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
+import { toast } from '@/hooks/use-toast'
 import { 
   AlertTriangle, 
   Save, 
@@ -91,6 +92,11 @@ export default function PerformanceConfigPage() {
       }
     } catch (error) {
       console.error('Failed to fetch config:', error)
+      toast({
+        title: 'Error',
+        description: 'Failed to fetch performance config',
+        variant: 'destructive'
+      })
     } finally {
       setLoading(false)
     }
@@ -135,6 +141,11 @@ export default function PerformanceConfigPage() {
       }
     } catch (error) {
       console.error('Failed to test config:', error)
+      toast({
+        title: 'Error',
+        description: 'Failed to test performance config',
+        variant: 'destructive'
+      })
     } finally {
       setTesting(false)
     }

--- a/frontend/app/history/page.tsx
+++ b/frontend/app/history/page.tsx
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Clock, CheckCircle, XCircle, AlertCircle, ChevronLeft, ChevronRight, RefreshCw, Eye } from 'lucide-react'
 import DashboardLayout from '../dashboard-layout'
 import { SyncDetailModal } from './sync-detail-modal'
+import { toast } from '@/hooks/use-toast'
 
 interface SyncHistory {
   sync_id: string
@@ -54,6 +55,11 @@ export default function HistoryPage() {
       setTotal(data.total || 0)
     } catch (error) {
       console.error('Failed to fetch history:', error)
+      toast({
+        title: 'Error',
+        description: 'Failed to fetch sync history',
+        variant: 'destructive'
+      })
     } finally {
       setLoading(false)
       setRefreshing(false)

--- a/frontend/app/history/sync-detail-modal.tsx
+++ b/frontend/app/history/sync-detail-modal.tsx
@@ -6,16 +6,17 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
-import { 
-  Clock, 
-  CheckCircle, 
-  XCircle, 
-  AlertCircle, 
+import {
+  Clock,
+  CheckCircle,
+  XCircle,
+  AlertCircle,
   TrendingUp,
   Activity,
   Zap,
   AlertTriangle
 } from 'lucide-react'
+import { toast } from '@/hooks/use-toast'
 
 interface SyncDetailModalProps {
   open: boolean
@@ -76,6 +77,11 @@ export function SyncDetailModal({ open, onClose, syncId }: SyncDetailModalProps)
       }
     } catch (error) {
       console.error('Failed to fetch sync details:', error)
+      toast({
+        title: 'Error',
+        description: 'Failed to fetch sync details',
+        variant: 'destructive'
+      })
     } finally {
       setLoading(false)
     }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -63,7 +63,7 @@ export default function Dashboard() {
       const data = await response.json()
       setStatus(data)
       setSyncing(data.sync_status === 'running')
-      
+
       // Fetch stats summary
       const statsResponse = await fetch('/api/sync/stats/summary')
       if (statsResponse.ok) {
@@ -72,6 +72,11 @@ export default function Dashboard() {
       }
     } catch (error) {
       console.error('Failed to fetch status:', error)
+      toast({
+        title: 'Error',
+        description: 'Failed to fetch system status',
+        variant: 'destructive'
+      })
     } finally {
       setLoading(false)
     }
@@ -98,6 +103,11 @@ export default function Dashboard() {
       }
     } catch (error) {
       console.error('Failed to start sync:', error)
+      toast({
+        title: 'Error',
+        description: 'Failed to start sync',
+        variant: 'destructive'
+      })
     }
   }
 
@@ -112,6 +122,11 @@ export default function Dashboard() {
       }
     } catch (error) {
       console.error('Failed to stop sync:', error)
+      toast({
+        title: 'Error',
+        description: 'Failed to stop sync',
+        variant: 'destructive'
+      })
     }
   }
 


### PR DESCRIPTION
## Summary
- surface status and sync errors on dashboard with destructive toasts
- show field mapping and cached field load failures via toasts
- add toast notifications across admin tools and history views when API calls fail

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6897e25e63cc83298259e9ee7a066de0