### PR TITLE
feat(ui): add success badge variant

### DIFF
--- a/frontend/components/ui/badge.tsx
+++ b/frontend/components/ui/badge.tsx
@@ -14,6 +14,8 @@ const badgeVariants = cva(
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        success:
+          "border-transparent bg-green-500 text-white hover:bg-green-500/80",
         outline: "text-foreground",
       },
     },


### PR DESCRIPTION
## Summary
- add `success` style to badge component for green status labels

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build` *(fails: failed to fetch `Inter` font from Google)*

------
https://chatgpt.com/codex/tasks/task_e_6897e248e6488329a2e14b2e4ee807ee